### PR TITLE
Minor output tweak, improve performance by defaulting to silent mode

### DIFF
--- a/ReleaseNotes/Generators/ExcelGenerator.cs
+++ b/ReleaseNotes/Generators/ExcelGenerator.cs
@@ -35,7 +35,7 @@ namespace ReleaseNotes
         /// Generates an excel instance
         /// </summary>
         /// <param name="settings"></param>
-        private ExcelGenerator(NamedLookup settings) : base(settings)
+        private ExcelGenerator(NamedLookup settings, bool silent) : base(settings, silent)
         {
             app = new Excel.Application();
             app.Visible = !this.silent;
@@ -51,11 +51,11 @@ namespace ReleaseNotes
         /// </summary>
         /// <param name="settings"></param>
         /// <returns></returns>
-        public static ExcelGenerator ExcelGeneratorFactory(NamedLookup settings)
+        public static ExcelGenerator ExcelGeneratorFactory(NamedLookup settings, bool silent)
         {
             try
             {
-                return new ExcelGenerator(settings);
+                return new ExcelGenerator(settings, silent);
             }
             catch (COMException e)
             {
@@ -396,7 +396,7 @@ namespace ReleaseNotes
             {
                 Excel.Range rowCell = getSingleCellRange(worksheet, 1, i);
                 rowCell.EntireRow.RowHeight = 28;
-            }
+            }			
         }
 
         /// <summary>

--- a/ReleaseNotes/Generators/HTMLGenerator.cs
+++ b/ReleaseNotes/Generators/HTMLGenerator.cs
@@ -10,8 +10,8 @@ namespace ReleaseNotes.Generators
 {
     class HTMLGenerator : ReleaseNotesGenerator
     {
-        public HTMLGenerator(NamedLookup settings)
-            : base(settings)
+        public HTMLGenerator(NamedLookup settings, bool silent)
+            : base(settings, silent)
         {
             throw new NotImplementedException();
         }

--- a/ReleaseNotes/Generators/ReleaseNotesGenerator.cs
+++ b/ReleaseNotes/Generators/ReleaseNotesGenerator.cs
@@ -42,13 +42,13 @@ namespace ReleaseNotes
         public virtual void createNewPage(string worksheetName) { }
         public virtual void save() { }
 
-        public ReleaseNotesGenerator(NamedLookup settings)
+        public ReleaseNotesGenerator(NamedLookup settings, bool silent)
         {
             this.settings = settings;
             checkRequiredFields();
             this.TFS = TFSAccessor.TFSAccessorFactory(settings["Team Project Path"], settings["Project Name"], settings["Iteration"]);
             this.logger = new Logger();
-            this.silent = false;
+            this.silent = silent;
         }
 
         public void checkRequiredFields()
@@ -90,9 +90,8 @@ namespace ReleaseNotes
         {
             NamedLookup executiveSummary = new NamedLookup("Executive Summary");
             executiveSummary["Application"] = settings["Project Name"];
-            executiveSummary["Release Date"] = DateTime.Now.ToShortDateString();
-            //executiveSummary["Release"] = settings["Project Name"] + " " + settings["Iteration"];
-            executiveSummary["Iteration (Sprint)"] = settings["Iteration"];
+            executiveSummary["Release Date"] = DateTime.Now.ToShortDateString();            
+            executiveSummary["Release (Sprint)"] = settings["Iteration"];
 			string buildNumber = TFS.getLatestBuildNumber();
 			if (buildNumber != null)
 			{
@@ -167,7 +166,7 @@ namespace ReleaseNotes
 
                 // done!
                 logger.setType(Logger.Type.Success)
-                    .setMessage("Document generated.")
+                    .setMessage("Document generated and saved in the current directory.")
                     .display();
             }
             catch (Exception e)

--- a/ReleaseNotes/Generators/WordGenerator.cs
+++ b/ReleaseNotes/Generators/WordGenerator.cs
@@ -23,7 +23,7 @@ namespace ReleaseNotes
         /// Generates a word instance
         /// </summary>
         /// <param name="settings"></param>
-        private WordGenerator(NamedLookup settings) : base(settings)
+        private WordGenerator(NamedLookup settings, bool silent) : base(settings, silent)
         {
             app = new Word.Application();
             app.Visible = !this.silent;
@@ -37,11 +37,11 @@ namespace ReleaseNotes
         /// </summary>
         /// <param name="settings"></param>
         /// <returns></returns>
-        public static WordGenerator WordGeneratorFactory(NamedLookup settings)
+        public static WordGenerator WordGeneratorFactory(NamedLookup settings, bool silent)
         {
             try
             {
-                return new WordGenerator(settings);
+                return new WordGenerator(settings, silent);
             }
             catch (COMException e)
             {

--- a/ReleaseNotes/Program.cs
+++ b/ReleaseNotes/Program.cs
@@ -13,8 +13,13 @@ namespace ReleaseNotes
     {
         static void Main(string[] args)
         {
-            // silent mode (server side?) is false by default
-            bool silent = false;
+            // silent mode is true by default -
+			// it's faster and quieter.
+            bool silent = true;
+
+			#if DEBUG
+				silent = false;
+			#endif
             
             if (!silent)
             {
@@ -51,10 +56,10 @@ namespace ReleaseNotes
                 switch (generatorType)
                 {
                     case "excel":
-                        generator = ExcelGenerator.ExcelGeneratorFactory(settings);
+                        generator = ExcelGenerator.ExcelGeneratorFactory(settings, silent);
                         break;
                     case "word":
-                        generator = WordGenerator.WordGeneratorFactory(settings);
+                        generator = WordGenerator.WordGeneratorFactory(settings, silent);
                         break;
                     case "html":
                         throw new NotImplementedException("Not implemented generator type");
@@ -74,7 +79,7 @@ namespace ReleaseNotes
                     .display();
             }
 
-            if (!silent)
+            if (!silent) //if we're in silent mode, the program exits. The file has been saved.
             {
                 // wait for exit
                 logger.setType(Logger.Type.General)


### PR DESCRIPTION
Output "Release (Sprint)" instead of "Iteration (Sprint)" because users are more familiar with that terminology.

When debugging, the default is still silent = false. But when built for release, silent = true so that the release notes run faster.

Let me know if you have questions.
